### PR TITLE
Support i18n.

### DIFF
--- a/actions-on-google.js
+++ b/actions-on-google.js
@@ -24,13 +24,27 @@ const protoFiles = require('google-proto-files');
 const { UserRefreshClient } = require('google-auth-library');
 const i18n = require('i18n');
 
-const SUPPORTED_LOCALES = ['en-US', 'fr-FR', 'ja-JP'];
+const SUPPORTED_LOCALES = [
+    'en-US', 'fr-FR', 'ja-JP', 'de-DE', 'ko-KR',
+    'es-ES', 'pt-BR', 'it-IT', 'ru-RU', 'hi-IN',
+    'th-TH', 'id-ID', 'da-DK', 'no-NO', 'nl-NL',
+    'sv-SE'
+];
+const FALLBACK_LOCALES = {
+    'en-GB': 'en-US',
+    'en-AU': 'en-US',
+    'en-SG': 'en-US',
+    'en-CA': 'en-US',
+    'fr-CA': 'fr-FR',
+    'es-419': 'es-ES'
+};
 const DEFAULT_LOCALE = SUPPORTED_LOCALES[0];
 
 i18n.configure({
-  locales: SUPPORTED_LOCALES,
-  directory: __dirname + '/locales',
-  defaultLocale: DEFAULT_LOCALE
+    locales: SUPPORTED_LOCALES,
+    fallbacks: FALLBACK_LOCALES,
+    directory: __dirname + '/locales',
+    defaultLocale: DEFAULT_LOCALE
 });
 
 const PROTO_ROOT_DIR = protoFiles('..');
@@ -71,7 +85,7 @@ class ActionsOnGoogle {
     }
 
     setLocale(locale) {
-        if (!SUPPORTED_LOCALES.includes(locale)) {
+        if (!SUPPORTED_LOCALES.concat(Object.keys(FALLBACK_LOCALES)).includes(locale)) {
             throw new Error(`Unsupported locale: ${locale}`);
         }
         this.locale = locale;

--- a/actions-on-google.js
+++ b/actions-on-google.js
@@ -86,7 +86,7 @@ class ActionsOnGoogle {
 
     setLocale(locale) {
         if (!SUPPORTED_LOCALES.concat(Object.keys(FALLBACK_LOCALES)).includes(locale)) {
-            throw new Error(`Unsupported locale: ${locale}`);
+            console.warn(`Warning: Unsupported locale '${locale}' in this tool. Ignore.`);
         }
         this.locale = locale;
         i18n.setLocale(locale);

--- a/actions-on-google.js
+++ b/actions-on-google.js
@@ -98,7 +98,7 @@ class ActionsOnGoogle {
         } else {
             return i18n.__(name);
         }
-    };
+    }
 
     setLocation(latLngArray) {
         this.location = latLngArray;

--- a/examples/number-genie/test/number-genie.test.js
+++ b/examples/number-genie/test/number-genie.test.js
@@ -34,7 +34,7 @@ const action = new ActionsOnGoogleAva(require('../../../test/test-credentials.js
 
 // Should start action, presetting the answer to fifty. Then guess a few times until the answer is 50.
 action.startTest('Number Genie - should guess the right answer', action => {
-    return action.startConversation('50')
+    return action.startConversation('about 50')
         .then(({ displayText, cards }) => {
             expect(displayText[0]).to.have.string("I'm thinking of a number from 0 to 100.");
             expect(displayText[1]).to.be.equal("What's your first guess?");
@@ -68,7 +68,7 @@ action.startTest('Number Genie - should guess the right answer', action => {
 
 // Should start action, presetting the answer to a number higher than the range 0-100
 action.startTest('Number Genie - starts with invalid number', action => {
-    return action.startConversation('250')
+    return action.startConversation('about 250')
         .then(({ displayText }) => {
             expect(displayText[0]).to.have.string("Woah there! I can't use that number.");
             expect(displayText[1]).to.be.equal("What's your first guess?");

--- a/locales/da-DK.json
+++ b/locales/da-DK.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "min testapp",
+  "start_conversation": "Tal med {{app_name}}",
+  "start_conversation_with_prompt": "Tal med {{app_name}} om {{prompt}}"
+}

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "meiner Test App",
+  "start_conversation": "Mit {{app_name}} sprechen",
+  "start_conversation_with_prompt": "Frage {{app_name}} nach {{prompt}}"
+}

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "my test app",
+  "start_conversation": "talk to {{app_name}}",
+  "start_conversation_with_prompt": "talk to {{app_name}} {{prompt}}"
+}

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1,6 +1,6 @@
 {
   "cancel": "cancel",
   "my_test_app": "my test app",
-  "start_conversation": "talk to {{app_name}}",
-  "start_conversation_with_prompt": "talk to {{app_name}} {{prompt}}"
+  "start_conversation": "Talk to {{app_name}}",
+  "start_conversation_with_prompt": "Talk to {{app_name}} {{prompt}}"
 }

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "mi aplicación de prueba",
+  "start_conversation": "Hablar con {{app_name}}",
+  "start_conversation_with_prompt": " Hablar con {{app_name}} {{prompt}}"
+}

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -1,6 +1,6 @@
 {
   "cancel": "annuler",
-  "my_test_app": "mon application de test",
-  "start_conversation": "parle avec {{app_name}}",
-  "start_conversation_with_prompt": "parle avec {{app_name}} {{prompt}}"
+  "my_test_app": "mon application test",
+  "start_conversation": "Parler avec {{app_name}}",
+  "start_conversation_with_prompt": "Parle avec {{app_name}} {{prompt}}"
 }

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "annuler",
+  "my_test_app": "mon application de test",
+  "start_conversation": "parle avec {{app_name}}",
+  "start_conversation_with_prompt": "parle avec {{app_name}} {{prompt}}"
+}

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "मेरा टेस्ट ऐप",
+  "start_conversation": "{{app_name}} से कनेक्ट करो",
+  "start_conversation_with_prompt": "{{app_name}} से पूछो {{prompt}}"
+}

--- a/locales/id-ID.json
+++ b/locales/id-ID.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "aplikasi uji saya",
+  "start_conversation": "Bicara dengan {{app_name}}",
+  "start_conversation_with_prompt": "Bicara dengan {{app_name}} {{prompt}}"
+}

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "mia app di prova",
+  "start_conversation": "Parla con {{app_name}}",
+  "start_conversation_with_prompt": "Parla con {{app_name}} {{prompt}}"
+}

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "テスト用アプリ",
+  "start_conversation": "{{app_name}}につないで",
+  "start_conversation_with_prompt": "{{app_name}}につないで、{{prompt}}"
+}

--- a/locales/ko-KR.json
+++ b/locales/ko-KR.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "취소",
+  "my_test_app": "테스트 앱",
+  "start_conversation": "{{app_name}}한테 말하기",
+  "start_conversation_with_prompt": "{{app_name}}한테 {{prompt}} 물어 볼래"
+}

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "mijn test-app",
+  "start_conversation": "Praat met {{app_name}}",
+  "start_conversation_with_prompt": "Vraag {{app_name}} om {{prompt}}"
+}

--- a/locales/no-NO.json
+++ b/locales/no-NO.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "estappen min",
+  "start_conversation": "Snakke med {{app_name}}",
+  "start_conversation_with_prompt": "Snakk med {{app_name}} om {{prompt}}"
+}

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancelar",
+  "my_test_app": "meu app de teste",
+  "start_conversation": "Falar com {{app_name}}",
+  "start_conversation_with_prompt": "Falar com {{app_name}} {{prompt}}"
+}

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "отмена",
+  "my_test_app": "моим тестовым приложением",
+  "start_conversation": "Говорить с {{app_name}}",
+  "start_conversation_with_prompt": "Говорить с {{app_name}} {{prompt}}"
+}

--- a/locales/sv-SE.json
+++ b/locales/sv-SE.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "min testapp",
+  "start_conversation": "Prata med {{app_name}}",
+  "start_conversation_with_prompt": "Snacka med {{app_name}} och {{prompt}}"
+}

--- a/locales/th-TH.json
+++ b/locales/th-TH.json
@@ -1,0 +1,6 @@
+{
+  "cancel": "cancel",
+  "my_test_app": "แอปทดสอบของฉัน",
+  "start_conversation": "คุยกับ {{app_name}}",
+  "start_conversation_with_prompt": "คุยกับ {{app_name}} {{prompt}}"
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "google-proto-files": "^0.16.0",
         "google-protobuf": "^3.3.0",
         "grpc": "^1.12.2",
+        "i18n": "^0.8.3",
         "mocha": "^3.0.2",
         "promise.prototype.finally": "3.1.0",
         "winston": "2.2.0"


### PR DESCRIPTION
Fix #2.

## What is this

To fix #2, I would like to introduce the mechanism to support i18n.

## How to introduce the mechanism

* Introduce the [i18n](https://www.npmjs.com/package/i18n) library to construct phrases for each language ([here](https://github.com/actions-on-google/actions-on-google-testing-nodejs/pull/1/files#diff-57724b090513769a78db5cbb4ef1d2bdR25)).
* Define each phrase in message resource bundle files. They are created for each language in the `locales` directory ([here](https://github.com/yoichiro/actions-on-google-testing-nodejs/tree/02b347fbda9d2d84df5d7c3b509999e3655a8d23/locales)).
* Construct a phrases to invoke the action using the i18n mechanism ([here](https://github.com/actions-on-google/actions-on-google-testing-nodejs/pull/1/files#diff-57724b090513769a78db5cbb4ef1d2bdR99)).