### PR TITLE
Change the license notation in the package.json file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "actions-on-google-testing",
     "description": "This is an end-to-end testing library for developers building actions",
     "version": "0.1.0",
-    "license": "Apache Version 2.0",
+    "license": "Apache-2.0",
     "author": "Google Inc.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
We need to use the short identifier defined by the SPDX in the package.json file. For instance, the short identifier for Apache License 2.0 is `Apache-2.0` ([see](https://spdx.org/licenses/Apache-2.0.html)).

Currently, when executing `yarn build` and so on, the following warning message will be output:

```bash
$ yarn build
yarn run v1.7.0
warning package.json: License should be a valid SPDX license expression
$ tsc && cp -r ./locales ./dist
✨  Done in 4.32s.
```

I would like to fix this issue by this pull request. Could you review this?