### PR TITLE
Add a new command to build and release this package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "build": "tsc && cp -r ./locales ./dist",
         "test": "yarn clean && yarn build && yarn lint && nyc ava --fail-fast dist/test/test.js",
         "docs": "typedoc --options typedoc.json",
-        "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs"
+        "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs",
+        "release": "yarn clean && yarn lint && yarn build && yarn publish"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
In the issue #18, it seems that we released the new version without building. Therefore, the released package didn't have a `dist` directory, I guess.

To ensure releasing this tool, I would like to add a new command `yarn release`. We can build and release at the same time by using the command, and we will avoid to occur the mistake like the issue #18.