### PR TITLE
Replace the method call from the deprecated method to the new one.

### DIFF
--- a/src/actions-on-google-ava.ts
+++ b/src/actions-on-google-ava.ts
@@ -46,7 +46,7 @@ export class ActionsOnGoogleAva extends ActionsOnGoogle {
                     console.log('test error', e)
                 })
                 .finally(() => {
-                    return this.endConversation()
+                    return this.cancel()
                         .then((res) => {
                             console.log('test ends')
                             this._t.end()


### PR DESCRIPTION
As the title. The deprecated method call is remained, because I forgot the replacing at #11. I would like to replace the deprecated method call to the new one.