### PR TITLE
Fix the MediaObject icon/largeImage issue

### DIFF
--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -152,11 +152,11 @@ interface ActionResponseItem extends JsonObject {
             name: string,
             description: string,
             contentUrl: string,
-            icon: {
-                url: string,
+            icon?: {
+                url?: string,
             },
-            largeImage: {
-                url: string,
+            largeImage?: {
+                url?: string,
             },
         }[],
     }
@@ -479,9 +479,9 @@ export class ActionsOnGoogle {
                                 description: i.mediaResponse.mediaObjects[0].description,
                                 sourceUrl: i.mediaResponse.mediaObjects[0].contentUrl,
                                 icon: i.mediaResponse.mediaObjects[0].icon
-                                    ? i.mediaResponse.mediaObjects[0].icon.url : undefined,
+                                    ? i.mediaResponse.mediaObjects[0].icon!.url : undefined,
                                 largeImage: i.mediaResponse.mediaObjects[0].largeImage
-                                    ? i.mediaResponse.mediaObjects[0].largeImage.url : undefined,
+                                    ? i.mediaResponse.mediaObjects[0].largeImage!.url : undefined,
                             }
                         } else if (i.tableCard) {
                             assistResponse.table = {

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -155,6 +155,9 @@ interface ActionResponseItem extends JsonObject {
             icon: {
                 url: string,
             },
+            largeImage: {
+                url: string,
+            },
         }[],
     }
 }
@@ -217,7 +220,8 @@ export interface AssistResponse {
         name: string,
         description: string,
         sourceUrl: string,
-        icon: string,
+        icon?: string,
+        largeImage?: string,
     },
     suggestions: string[],
     linkOutSuggestion?: {
@@ -474,7 +478,10 @@ export class ActionsOnGoogle {
                                 name: i.mediaResponse.mediaObjects[0].name,
                                 description: i.mediaResponse.mediaObjects[0].description,
                                 sourceUrl: i.mediaResponse.mediaObjects[0].contentUrl,
-                                icon: i.mediaResponse.mediaObjects[0].icon.url,
+                                icon: i.mediaResponse.mediaObjects[0].icon
+                                    ? i.mediaResponse.mediaObjects[0].icon.url : undefined,
+                                largeImage: i.mediaResponse.mediaObjects[0].largeImage
+                                    ? i.mediaResponse.mediaObjects[0].largeImage.url : undefined,
                             }
                         } else if (i.tableCard) {
                             assistResponse.table = {

--- a/src/test/expected.ts
+++ b/src/test/expected.ts
@@ -583,7 +583,7 @@ export const CONVERSATION_LIST = {
   },
 }
 
-export const CONVERSATION_MEDIA = {
+export const CONVERSATION_MEDIA_WITH_ICON = {
   conversationToken: '[\"_actions_on_google_\"]',
   expectUserResponse: true,
   expectedInputs: [
@@ -650,6 +650,75 @@ export const CONVERSATION_MEDIA = {
       intent: '88cb82e1-9d72-4d70-bef1-be5b39dff99f',
     },
   },
+}
+
+export const CONVERSATION_MEDIA_WITH_LARGEIMAGE = {
+    conversationToken: '[\"_actions_on_google_\"]',
+    expectUserResponse: true,
+    expectedInputs: [
+        {
+            inputPrompt: {
+                richInitialPrompt: {
+                    items: [
+                        {
+                            simpleResponse: {
+                                textToSpeech: 'This is the first simple response for a media response',
+                            },
+                        },
+                        {
+                            mediaResponse: {
+                                mediaType: 'AUDIO',
+                                mediaObjects: [
+                                    {
+                                        name: 'Jazz in Paris',
+                                        description: 'A funky Jazz tune',
+                                        contentUrl: 'http://storage.googleapis.com/automotive-media/Jazz_In_Paris.mp3',
+                                        largeImage: {
+                                            url: 'http://storage.googleapis.com/automotive-media/album_art.jpg',
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    suggestions: [
+                        {
+                            title: 'Basic Card',
+                        },
+                        {
+                            title: 'Browse Carousel',
+                        },
+                        {
+                            title: 'Carousel',
+                        },
+                        {
+                            title: 'List',
+                        },
+                        {
+                            title: 'Media',
+                        },
+                        {
+                            title: 'Suggestions',
+                        },
+                    ],
+                },
+            },
+            possibleIntents: [
+                {
+                    intent: 'assistant.intent.action.TEXT',
+                },
+            ],
+        },
+    ],
+    responseMetadata: {
+        status: {
+            message: 'Success (200)',
+        },
+        queryMatchInfo: {
+            queryMatched: true,
+            intent: '88cb82e1-9d72-4d70-bef1-be5b39dff99f',
+        },
+    },
 }
 
 export const CONVERSATION_LINKOUT_SUGGESTION = {

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -297,11 +297,11 @@ test.serial('verifies parsing a list', t => {
     })
 })
 
-test.serial('verifies parsing a media response', t => {
+test.serial('verifies parsing a media response with icon', t => {
   const action = new ActionsOnGoogleAva(require(testCredentialsFile))
   const mockResponse = sinon.stub(action._client, 'assist')
   mockResponse.callsFake(() => {
-    const conversation = getMockConversation(Sample.CONVERSATION_MEDIA)
+    const conversation = getMockConversation(Sample.CONVERSATION_MEDIA_WITH_ICON)
     return conversation
   })
 
@@ -314,8 +314,31 @@ test.serial('verifies parsing a media response', t => {
         'http://storage.googleapis.com/automotive-media/Jazz_In_Paris.mp3')
       t.is(res.mediaResponse!.icon,
         'http://storage.googleapis.com/automotive-media/album_art.jpg')
+      t.is(res.mediaResponse!.largeImage, undefined)
       mockResponse.restore()
     })
+})
+
+test.serial('verifies parsing a media response with largeImage', t => {
+    const action = new ActionsOnGoogleAva(require(testCredentialsFile))
+    const mockResponse = sinon.stub(action._client, 'assist')
+    mockResponse.callsFake(() => {
+        const conversation = getMockConversation(Sample.CONVERSATION_MEDIA_WITH_LARGEIMAGE)
+        return conversation
+    })
+
+    return action.start('')
+        .then((res: AssistResponse) => {
+            t.is(res.mediaResponse!.type, 'AUDIO')
+            t.is(res.mediaResponse!.name, 'Jazz in Paris')
+            t.is(res.mediaResponse!.description, 'A funky Jazz tune')
+            t.is(res.mediaResponse!.sourceUrl,
+                'http://storage.googleapis.com/automotive-media/Jazz_In_Paris.mp3')
+            t.is(res.mediaResponse!.icon, undefined)
+            t.is(res.mediaResponse!.largeImage,
+                'http://storage.googleapis.com/automotive-media/album_art.jpg')
+            mockResponse.restore()
+        })
 })
 
 test.serial('verifies parsing a linkout suggestion', t => {


### PR DESCRIPTION
Fix the #24 

# What is this pull request

This pull request has a fix code to resolve the issue #24. The [current code](https://github.com/actions-on-google/actions-on-google-testing-nodejs/blob/master/src/actions-on-google.ts#L477) expects that each MediaObject object has an `icon` value including the `url` child value. However, it is possible to specify a `largeImage` value, instead of the `icon` value in the [specification of the MediaObject](https://developers.google.com/actions/reference/rest/Shared.Types/AppResponse#mediaobject).

Both the `icon` and the `largeImage` must be applied. This pull request changes the code to apply both them.

# How to change the code

Currently, the `icon` property is required. I would like to change that the `icon` property is optional. In addition, I would like to add a new property called `largeImage` to the `mediaResponse` interface definition. Of course, the `largeImage` is also optional.