### PR TITLE
include supplemental_display_text in textToSpeech

### DIFF
--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -509,7 +509,7 @@ export class ActionsOnGoogle {
                 if (data.dialog_state_out) {
                     this._conversationState = data.dialog_state_out.conversation_state
                     if (data.dialog_state_out.supplemental_display_text &&
-                        !assistResponse.displayText) {
+                        !assistResponse.displayText.length) {
                         assistResponse.textToSpeech =
                             [data.dialog_state_out.supplemental_display_text]
                     }


### PR DESCRIPTION
Since `displayText` is initialized to `[]` the expression `!assistResponse.displayText` will always be false. This prevents having the `textToSpeech` array take the value of `data.dialog_state_out.supplemental_display_text` as desired.

This likely contributes to issue #29