### PR TITLE
Removed call to t.plan() to improve tap and JUnit report output

### DIFF
--- a/src/actions-on-google-ava.ts
+++ b/src/actions-on-google-ava.ts
@@ -55,7 +55,6 @@ export class ActionsOnGoogleAva extends ActionsOnGoogle {
         this._isNewConversation = true
         test(testName, async t => {
             this._t = t
-            this._t.plan(1)
             console.log(`** Starting test ${testName} **`)
             try {
               await callback(this)
@@ -66,6 +65,8 @@ export class ActionsOnGoogleAva extends ActionsOnGoogle {
               this._t.pass()
             } catch(e) {
               console.log('test error', e)
+              // let ava handle the error
+              throw e
             } finally {
               await this.cancel()
               console.log('test ends')


### PR DESCRIPTION
If `t.plan(1)` is called, then the only text in the report is that the test expected one assertion and got a different number.

Compare:

```
            name: AssertionError
            message: Planned for 1 assertion, but got 0.
            assertion: plan
            operator: ===
            at: ActionsOnGoogleAva.<anonymous> (node_modules/actions-on-google-testing/src/actions-on-google-ava.ts:58:21)
```

and 

```
          ---
            name: AssertionError
            message: Rejected promise returned by test
            values: {"Rejected promise returned by test. Reason:":"AssertionError [ERR_ASSERTION] (AssertionError) {\n  actual: '&lt;speak&gt;Your basket is now empty.&lt;/speak&gt;',\n  code: 'ERR_ASSERTION',\n  expected: '&lt;speak&gt;Your basket is now full.&lt;/speak&gt;',\n  generatedMessage: true,\n  operator: '==',\n  message: '\\'&lt;speak&gt;Your basket is now empty.&lt;/speak&gt;\\' == \\'Your basket is now empty.X\\'',\n}"}
            at: equal (functional-test/add-remove-over-min-spend-test.js:14:14)
          ...
```

See https://github.com/avajs/ava/blob/master/docs/recipes/when-to-use-plan.md