### PR TITLE
Adding Audio to response. Ignore supplemental_display_text if other text available.

### DIFF
--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -245,6 +245,7 @@ export interface AssistResponse {
     deviceAction?: string
     signInIntent?: boolean
     audioOut?: Buffer
+    screenOutHtml?: string
 }
 
 /**
@@ -482,6 +483,8 @@ export class ActionsOnGoogle {
         config.getAudioOutConfig().setEncoding(1)
         config.getAudioOutConfig().setSampleRateHertz(16000)
         config.getAudioOutConfig().setVolumePercentage(100)
+        config.setScreenOutConfig(new embeddedAssistantPb.ScreenOutConfig());
+        config.getScreenOutConfig().setScreenMode('PLAYING')
         config.setDialogStateIn(new embeddedAssistantPb.DialogStateIn())
         config.setDeviceConfig(new embeddedAssistantPb.DeviceConfig())
         config.getDialogStateIn().setLanguageCode(this._locale)
@@ -682,6 +685,9 @@ export class ActionsOnGoogle {
                             name: actionResponse.linkOutSuggestion.destinationName,
                         }
                     }
+                }
+                if (data.screen_out && data.screen_out.format === 'HTML' && data.screen_out.data  ) {
+                    assistResponse.screenOutHtml = data.screen_out.data.toString()
                 }
             })
             conversation.on('end', () => {

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -282,6 +282,12 @@ export class ActionsOnGoogle {
     /** @public */
     deviceInstanceId = 'default'
 
+    /** @public */
+    includeAudioOut = false
+
+    /** @public */
+    includeScreenOut = false
+
     /**
      * Constructs a new ActionsOnGoogle object and initializes a gRPC client
      *
@@ -483,8 +489,10 @@ export class ActionsOnGoogle {
         config.getAudioOutConfig().setEncoding(1)
         config.getAudioOutConfig().setSampleRateHertz(16000)
         config.getAudioOutConfig().setVolumePercentage(100)
-        config.setScreenOutConfig(new embeddedAssistantPb.ScreenOutConfig())
-        config.getScreenOutConfig().setScreenMode('PLAYING')
+        if (this.includeScreenOut) {
+            config.setScreenOutConfig(new embeddedAssistantPb.ScreenOutConfig())
+            config.getScreenOutConfig().setScreenMode('PLAYING')
+        }
         config.setDialogStateIn(new embeddedAssistantPb.DialogStateIn())
         config.setDeviceConfig(new embeddedAssistantPb.DeviceConfig())
         config.getDialogStateIn().setLanguageCode(this._locale)
@@ -522,7 +530,7 @@ export class ActionsOnGoogle {
             const audioBuffers: Buffer[] = []
 
             conversation.on('data', (data: AssistantSdkResponse) => {
-                if (data.audio_out && data.audio_out.audio_data) {
+                if (this.includeAudioOut && data.audio_out && data.audio_out.audio_data) {
                     audioBuffers.push(data.audio_out.audio_data)
                 }
 
@@ -686,12 +694,13 @@ export class ActionsOnGoogle {
                         }
                     }
                 }
-                if (data.screen_out && data.screen_out.format === 'HTML' && data.screen_out.data) {
+                if (this.includeScreenOut && data.screen_out
+                    && data.screen_out.format === 'HTML' && data.screen_out.data) {
                     assistResponse.screenOutHtml = data.screen_out.data.toString()
                 }
             })
             conversation.on('end', () => {
-                if (audioBuffers.length > 0) {
+                if (this.includeAudioOut && audioBuffers.length > 0) {
                     assistResponse.audioOut = Buffer.concat(audioBuffers)
                 }
 

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -503,7 +503,7 @@ export class ActionsOnGoogle {
         config.getAudioOutConfig().setEncoding(1)
         config.getAudioOutConfig().setSampleRateHertz(16000)
         config.getAudioOutConfig().setVolumePercentage(100)
-        if (this.include.screenOut) {
+        if (this.include && this.include.screenOut) {
             config.setScreenOutConfig(new embeddedAssistantPb.ScreenOutConfig())
             config.getScreenOutConfig().setScreenMode('PLAYING')
         }

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -282,11 +282,25 @@ export class ActionsOnGoogle {
     /** @public */
     deviceInstanceId = 'default'
 
-    /** @public */
-    includeAudioOut = false
-
-    /** @public */
-    includeScreenOut = false
+    /**
+     * Flags to include/exclude certain response data
+     * audioOut - include/exclude response audio buffer (if available)
+     * screenOut - include/exclude response screen output (HTML) (if available)
+     *
+     * @example
+     * ```javascript
+     * const action = new ActionsOnGoogleAva(CREDENTIALS);
+     * action.include.audioOut = true;
+     * action.include.screenOut = true;
+     * action.include = { audioOut: true, screenOut = false };
+     * ```
+     *
+     * @public
+     */
+    include = {
+        audioOut: false,
+        screenOut: false,
+    }
 
     /**
      * Constructs a new ActionsOnGoogle object and initializes a gRPC client
@@ -489,7 +503,7 @@ export class ActionsOnGoogle {
         config.getAudioOutConfig().setEncoding(1)
         config.getAudioOutConfig().setSampleRateHertz(16000)
         config.getAudioOutConfig().setVolumePercentage(100)
-        if (this.includeScreenOut) {
+        if (this.include.screenOut) {
             config.setScreenOutConfig(new embeddedAssistantPb.ScreenOutConfig())
             config.getScreenOutConfig().setScreenMode('PLAYING')
         }
@@ -530,7 +544,8 @@ export class ActionsOnGoogle {
             const audioBuffers: Buffer[] = []
 
             conversation.on('data', (data: AssistantSdkResponse) => {
-                if (this.includeAudioOut && data.audio_out && data.audio_out.audio_data) {
+                if (this.include && this.include.audioOut &&
+                    data.audio_out && data.audio_out.audio_data) {
                     audioBuffers.push(data.audio_out.audio_data)
                 }
 
@@ -694,13 +709,13 @@ export class ActionsOnGoogle {
                         }
                     }
                 }
-                if (this.includeScreenOut && data.screen_out
+                if (this.include && this.include.screenOut && data.screen_out
                     && data.screen_out.format === 'HTML' && data.screen_out.data) {
                     assistResponse.screenOutHtml = data.screen_out.data.toString()
                 }
             })
             conversation.on('end', () => {
-                if (this.includeAudioOut && audioBuffers.length > 0) {
+                if (this.include && this.include.audioOut && audioBuffers.length > 0) {
                     assistResponse.audioOut = Buffer.concat(audioBuffers)
                 }
 

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -483,7 +483,7 @@ export class ActionsOnGoogle {
         config.getAudioOutConfig().setEncoding(1)
         config.getAudioOutConfig().setSampleRateHertz(16000)
         config.getAudioOutConfig().setVolumePercentage(100)
-        config.setScreenOutConfig(new embeddedAssistantPb.ScreenOutConfig());
+        config.setScreenOutConfig(new embeddedAssistantPb.ScreenOutConfig())
         config.getScreenOutConfig().setScreenMode('PLAYING')
         config.setDialogStateIn(new embeddedAssistantPb.DialogStateIn())
         config.setDeviceConfig(new embeddedAssistantPb.DeviceConfig())
@@ -686,7 +686,7 @@ export class ActionsOnGoogle {
                         }
                     }
                 }
-                if (data.screen_out && data.screen_out.format === 'HTML' && data.screen_out.data  ) {
+                if (data.screen_out && data.screen_out.format === 'HTML' && data.screen_out.data) {
                     assistResponse.screenOutHtml = data.screen_out.data.toString()
                 }
             })

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -520,7 +520,9 @@ export class ActionsOnGoogle {
                 if (data.dialog_state_out) {
                     this._conversationState = data.dialog_state_out.conversation_state
                     if (data.dialog_state_out.supplemental_display_text &&
-                        !assistResponse.displayText.length) {
+                        (!assistResponse.displayText.length &&
+                            !assistResponse.textToSpeech.length &&
+                            !assistResponse.ssml.length)) {
                         assistResponse.textToSpeech =
                             [data.dialog_state_out.supplemental_display_text]
                     }

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -40,6 +40,8 @@ const FALLBACK_LOCALES = {
 
 const DEFAULT_LOCALE = SUPPORTED_LOCALES[0]
 
+const SCREENOUT_FORMAT_HTML = 'HTML'
+
 i18n.configure({
     locales: SUPPORTED_LOCALES,
     fallbacks: FALLBACK_LOCALES,
@@ -552,9 +554,9 @@ export class ActionsOnGoogle {
                 if (data.dialog_state_out) {
                     this._conversationState = data.dialog_state_out.conversation_state
                     if (data.dialog_state_out.supplemental_display_text &&
-                        (!assistResponse.displayText.length &&
-                            !assistResponse.textToSpeech.length &&
-                            !assistResponse.ssml.length)) {
+                        !assistResponse.displayText.length &&
+                        !assistResponse.textToSpeech.length &&
+                        !assistResponse.ssml.length) {
                         assistResponse.textToSpeech =
                             [data.dialog_state_out.supplemental_display_text]
                     }
@@ -710,7 +712,7 @@ export class ActionsOnGoogle {
                     }
                 }
                 if (this.include && this.include.screenOut && data.screen_out
-                    && data.screen_out.format === 'HTML' && data.screen_out.data) {
+                    && data.screen_out.format === SCREENOUT_FORMAT_HTML && data.screen_out.data) {
                     assistResponse.screenOutHtml = data.screen_out.data.toString()
                 }
             })

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -41,6 +41,8 @@ const testCredentials: UserCredentials = {
   type: 'authorized_user',
 }
 
+const HTML_SAMPLE = '<html><body>hello</body></html>'
+
 // Mock implementation of gRPC call that allows server response to be mocked
 // tslint:disable-next-line
 const getMockConversation = (data: any, audioOutBuffer?: Buffer, screenOutHtml?: String) => {
@@ -420,9 +422,8 @@ test.serial('verifies parsing a new surface intent', t => {
     })
 })
 
-test.serial('verifies missing audioOut', t => {
+test.serial('verifies missing audioOut (default setting)', t => {
   const action = new ActionsOnGoogleAva(testCredentials)
-  action.includeAudioOut = false
   const mockResponse = sinon.stub(action._client, 'assist')
   mockResponse.callsFake(() => {
     const conversation = getMockConversation(Sample.CONVERSATION_WELCOME, Buffer.alloc(0))
@@ -438,7 +439,7 @@ test.serial('verifies missing audioOut', t => {
 
 test.serial('verifies receipt of audioOut', t => {
   const action = new ActionsOnGoogleAva(testCredentials)
-  action.includeAudioOut = true
+  action.include.audioOut = true
   const mockResponse = sinon.stub(action._client, 'assist')
   mockResponse.callsFake(() => {
     const conversation = getMockConversation(Sample.CONVERSATION_WELCOME, Buffer.alloc(0))
@@ -452,12 +453,11 @@ test.serial('verifies receipt of audioOut', t => {
     })
 })
 
-test.serial('verifies missing screenOutHtml', t => {
+test.serial('verifies missing screenOutHtml (default setting)', t => {
   const action = new ActionsOnGoogleAva(testCredentials)
-  action.includeScreenOut = false
   const mockResponse = sinon.stub(action._client, 'assist')
   mockResponse.callsFake(() => {
-    const conversation = getMockConversation(Sample.CONVERSATION_WELCOME, undefined, 'my html')
+    const conversation = getMockConversation(Sample.CONVERSATION_WELCOME, undefined, HTML_SAMPLE)
     return conversation
   })
 
@@ -470,16 +470,16 @@ test.serial('verifies missing screenOutHtml', t => {
 
 test.serial('verifies receipt of screenOutHtml', t => {
   const action = new ActionsOnGoogleAva(testCredentials)
-  action.includeScreenOut = true
+  action.include.screenOut = true
   const mockResponse = sinon.stub(action._client, 'assist')
   mockResponse.callsFake(() => {
-    const conversation = getMockConversation(Sample.CONVERSATION_WELCOME, undefined, 'my html')
+    const conversation = getMockConversation(Sample.CONVERSATION_WELCOME, undefined, HTML_SAMPLE)
     return conversation
   })
 
   return action!.start('')
     .then((res: AssistResponse) => {
-      t.is(res.screenOutHtml, 'my html')
+      t.is(res.screenOutHtml, HTML_SAMPLE)
       mockResponse.restore()
     })
 })


### PR DESCRIPTION
There are three amendments in this PR (at least for my purpose they are, I hope for others as well).

1. Audio stream is collected and added as _audioOut_ to the test call response.
2. The supplemental_display_text is ignored if any other text value is identified.
3. ScreenOut HTML is collected added as _screenOutHtml_ to the test call response.