### PR TITLE
Avoid cancel when mic closed + update node to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs",
         "release": "yarn clean && yarn lint && yarn build && yarn publish && yarn release:changelog",
         "release:changelog": "sh script/changelog.sh",
-        "postinstall": "yarn build"
+        "postinstall": "tsc -p ./tsconfig.json && cp -r ./locales ./dist"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs",
         "release": "yarn clean && yarn lint && yarn build && yarn publish && yarn release:changelog",
         "release:changelog": "sh script/changelog.sh",
-        "postinstall": "npx tsc -p ./tsconfig.json && cp -r ./locales ./dist"
+        "postinstall": "npx tsc -p . && cp -r ./locales ./dist"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "engines": {
-        "node": ">=8.9.4"
+        "node": ">=10.13.0"
     },
     "scripts": {
         "clean": "rm -rf dist docs",
@@ -21,7 +21,7 @@
         "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs",
         "release": "yarn clean && yarn lint && yarn build && yarn publish && yarn release:changelog",
         "release:changelog": "sh script/changelog.sh",
-        "postinstall": "npx tsc -p . && cp -r ./locales ./dist"
+        "prepare": "yarn build"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs",
         "release": "yarn clean && yarn lint && yarn build && yarn publish && yarn release:changelog",
         "release:changelog": "sh script/changelog.sh",
-        "postinstall": "tsc -p ./tsconfig.json && cp -r ./locales ./dist"
+        "postinstall": "npx tsc -p ./tsconfig.json && cp -r ./locales ./dist"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "docs": "typedoc --options typedoc.json",
         "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs",
         "release": "yarn clean && yarn lint && yarn build && yarn publish && yarn release:changelog",
-        "release:changelog": "sh script/changelog.sh"
+        "release:changelog": "sh script/changelog.sh",
+        "postinstall": "yarn build"
     },
     "repository": {
         "type": "git",

--- a/src/actions-on-google-ava.ts
+++ b/src/actions-on-google-ava.ts
@@ -68,7 +68,9 @@ export class ActionsOnGoogleAva extends ActionsOnGoogle {
               // let ava handle the error
               throw e
             } finally {
-              await this.cancel()
+              if (!this._micHasClosed){
+                await this.cancel()
+              }
               console.log('test ends')
               console.log('\n')
             }

--- a/src/actions-on-google-ava.ts
+++ b/src/actions-on-google-ava.ts
@@ -53,6 +53,7 @@ export class ActionsOnGoogleAva extends ActionsOnGoogle {
     // tslint:disable-next-line
     startTest(testName: string, callback: (t: ActionsOnGoogleAva) => Promise<any>) {
         this._isNewConversation = true
+        this._micHasClosed = false
         test(testName, async t => {
             this._t = t
             console.log(`** Starting test ${testName} **`)

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -85,9 +85,9 @@ interface JsonObject {
 }
 
 enum MicrophoneMode {
-  MICROPHONE_MODE_UNSPECIFIED = "MICROPHONE_MODE_UNSPECIFIED",
-  CLOSE_MICROPHONE = "CLOSE_MICROPHONE",
-  DIALOG_FOLLOW_ON = "DIALOG_FOLLOW_ON",
+  MICROPHONE_MODE_UNSPECIFIED = 'MICROPHONE_MODE_UNSPECIFIED',
+  CLOSE_MICROPHONE = 'CLOSE_MICROPHONE',
+  DIALOG_FOLLOW_ON = 'DIALOG_FOLLOW_ON',
 }
 
 interface AssistantSdkResponse extends JsonObject {
@@ -265,6 +265,7 @@ export class ActionsOnGoogle {
     // tslint:disable-next-line
     _client: any
     /** @hidden reference to ava test to allow logging */
+    // tslint:disable-next-line
     _t: any
     /** @hidden */
     _conversationState: Uint8Array

--- a/src/actions-on-google.ts
+++ b/src/actions-on-google.ts
@@ -553,7 +553,6 @@ export class ActionsOnGoogle {
                 displayText: [],
                 ssml: [],
                 suggestions: [],
-                newSurface: undefined,
             }
             const audioBuffers: Buffer[] = []
 

--- a/src/test/expected.ts
+++ b/src/test/expected.ts
@@ -108,6 +108,11 @@ export const NUMBER_GENIE_WELCOME_VALUES = {
   suggestions: ['37', '10', '78', '34'],
 }
 
+export const NUMBER_GENIE_WELCOME_WITHOUT_DEBUG_INFO = {
+  supplemental_display_text: 'Hi! I\'m thinking of a number from 0 to 100.\nWhat\'s your first guess?',
+  microphone_mode: 'DIALOG_FOLLOW_ON',
+}
+
 export const NUMBER_GENIE_EXIT = {
   conversationToken: '[\"_actions_on_google\",\"game\",\"yes_no\"]',
   finalResponse: {
@@ -132,6 +137,11 @@ export const NUMBER_GENIE_EXIT = {
     },
   },
   userStorage: '{\"data\":{}}',
+}
+
+export const NUMBER_GENIE_EXIT_WITHOUT_DEBUG_INFO = {
+  supplemental_display_text: 'OK, I\'m already thinking of a number for next time.',
+  microphone_mode: 'CLOSE_MICROPHONE',
 }
 
 export const CONVERSATION_WELCOME = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "es2017",
         "module": "commonjs",
         "moduleResolution": "node",
         "outDir": "./dist",


### PR DESCRIPTION
It appears that AoG has changed how it behaves when given input outside of the action. Previously it would ignore that input and leave the conversation closed. Now it appears to open a new conversation which confuses the tests.

Consequently, always saying "cancel" after every test will cause problems when there are multiple tests in a single file.

This PR detects when the mic is closed and skips saying "cancel" if so.

Another change that appears to have happened to AoG is that the `debug_info` content is no longer being returned. This means that much of the content (including the previous flag for the microphone being closed!) is no longer available.

This PR grabs the `microphone_mode` value from the `dialog_state_out` which is still returned to discover if the mic has been closed.


### Additional changes in this PR

Added a prepare lifecycle step to `package.json` so that the project can be used as a dependency straight from a github branch.

Updated node to v10 and typescript output to ES2017 to match -- node 8 is now deprecated and node 10 is the minimum LTS. Completely understand if you want to do the node update as a separate PR.