### PR TITLE
Updated node to v10 and typescript output to ES2017 to match

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "engines": {
-        "node": ">=8.9.4"
+        "node": ">=10.13.0"
     },
     "scripts": {
         "clean": "rm -rf dist docs",
@@ -19,6 +19,7 @@
         "test:ci": "yarn test && yarn test:git && yarn test:tar",
         "docs": "typedoc --options typedoc.json",
         "docs:clean": "rm -rf docs && mkdir docs && touch docs/.nojekyll && yarn docs",
+        "prepare": "yarn build",
         "release": "yarn clean && yarn lint && yarn build && yarn publish && yarn release:changelog",
         "release:changelog": "sh script/changelog.sh"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "es2017",
         "module": "commonjs",
         "moduleResolution": "node",
         "outDir": "./dist",


### PR DESCRIPTION
node 8 is now deprecated and node 10 is the minimum LTS.

Added a prepare lifecycle step to package.json so that the project
can be used as a dependency straight from a github branch.